### PR TITLE
Fixed Python Extended syntax

### DIFF
--- a/python.JSON-tmLanguage
+++ b/python.JSON-tmLanguage
@@ -1293,7 +1293,7 @@
                             "beginCaptures": {
                                 "0": { "name": "variable.parameter.function.python" }
                             },
-                            "end": "(^\\s*$|(?=\"\"\"))",
+                            "end": "(^\\s*$|\\s*(?=\"\"\"))",
                             "patterns": [
                                 {
                                     "match": "^\\s*(\\w*)\\s*\\{([^\\{\\}]*)\\}\\s*--\\s*(.*)$",
@@ -1310,7 +1310,7 @@
                             "beginCaptures": {
                                 "0": { "name": "constant.numeric.integer.decimal.python" }
                             },
-                            "end": "(^\\s*$|(?=\"\"\"))",
+                            "end": "(^\\s*$|\\s*(?=\"\"\"))",
                             "patterns": [
                                 {
                                     "match": "^\\s*(\\w*)\\s*\\{([^\\{\\}]*)\\}(\\s*--)?\\s*(.*)?$",
@@ -1327,14 +1327,14 @@
                             "beginCaptures": {
                                 "0": { "name": "support.function.magic.python" }
                             },
-                            "end": "(^\\s*$|(?=\"\"\"))"
+                            "end": "(^\\s*$|\\s*(?=\"\"\"))"
                         },
                         {
                             "begin": "^\\s*([Ee]xtends|[Dd]ecorators)(:)?\\s*$",
                             "beginCaptures": {
                                 "0": { "name": "entity.name.function.decorator.python" }
                             },
-                            "end": "(^\\s*$|(?=\"\"\"))",
+                            "end": "(^\\s*$|\\s*(?=\"\"\"))",
                             "patterns": [
                                 {
                                     "match": "^(.*)$",
@@ -1349,7 +1349,7 @@
                             "beginCaptures": {
                                 "0": { "name": "keyword.other.python" }
                             },
-                            "end": "(^\\s*$|(?=\"\"\"))",
+                            "end": "(^\\s*$|\\s*(?=\"\"\"))",
                             "patterns": [
                                 {
                                     "match": "^\\s*\\{([^\\{\\}]*)\\}",

--- a/python.tmLanguage
+++ b/python.tmLanguage
@@ -2249,7 +2249,7 @@
 								</dict>
 							</dict>
 							<key>end</key>
-							<string>(^\s*$|(?="""))</string>
+							<string>(^\s*$|\s*(?="""))</string>
 							<key>patterns</key>
 							<array>
 								<dict>
@@ -2288,7 +2288,7 @@
 								</dict>
 							</dict>
 							<key>end</key>
-							<string>(^\s*$|(?="""))</string>
+							<string>(^\s*$|\s*(?="""))</string>
 							<key>patterns</key>
 							<array>
 								<dict>
@@ -2327,7 +2327,7 @@
 								</dict>
 							</dict>
 							<key>end</key>
-							<string>(^\s*$|(?="""))</string>
+							<string>(^\s*$|\s*(?="""))</string>
 						</dict>
 						<dict>
 							<key>begin</key>
@@ -2341,7 +2341,7 @@
 								</dict>
 							</dict>
 							<key>end</key>
-							<string>(^\s*$|(?="""))</string>
+							<string>(^\s*$|\s*(?="""))</string>
 							<key>patterns</key>
 							<array>
 								<dict>
@@ -2370,7 +2370,7 @@
 								</dict>
 							</dict>
 							<key>end</key>
-							<string>(^\s*$|(?="""))</string>
+							<string>(^\s*$|\s*(?="""))</string>
 							<key>patterns</key>
 							<array>
 								<dict>


### PR DESCRIPTION
- Ending the sub-scopes of the doc blocks properly at the end of
  the docstring `"""`
- Resolves #13
