### PR TITLE
Allow ''' in addition to """ for docstring quotes

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -6,11 +6,11 @@
     ],
     "command": "docblockr_python",
     "context": [
-      { "key": "selector",              "operator": "equal",          "operand": "string.quoted.double.block", "match_all": false },
-      { "key": "setting.auto_indent",   "operator": "equal",          "operand": true,                         "match_all": true },
-      { "key": "selection_empty",       "operator": "equal",          "operand": true,                         "match_all": true },
-      { "key": "auto_complete_visible", "operator": "equal",          "operand": false,                        "match_all": true },
-      { "key": "preceding_text",        "operator": "regex_contains", "operand": "^\\s*(\"\"\")\\s*$",         "match_all": true }
+      { "key": "selector",              "operator": "equal",          "operand": "string.quoted.double.block",         "match_all": false },
+      { "key": "setting.auto_indent",   "operator": "equal",          "operand": true,                                 "match_all": true },
+      { "key": "selection_empty",       "operator": "equal",          "operand": true,                                 "match_all": true },
+      { "key": "auto_complete_visible", "operator": "equal",          "operand": false,                                "match_all": true },
+      { "key": "preceding_text",        "operator": "regex_contains", "operand": "^\\s*(\"\"\"|''')\\s*$",             "match_all": true }
     ]
   },
   {
@@ -19,11 +19,11 @@
     ],
     "command": "docblockr_python",
     "context": [
-      { "key": "selector",              "operator": "equal",          "operand": "string.quoted.double.block", "match_all": false },
-      { "key": "setting.auto_indent",   "operator": "equal",          "operand": true,                         "match_all": true },
-      { "key": "selection_empty",       "operator": "equal",          "operand": true,                         "match_all": true },
-      { "key": "auto_complete_visible", "operator": "equal",          "operand": false,                        "match_all": true },
-      { "key": "preceding_text",        "operator": "regex_contains", "operand": "^\\s*(\"\"\")\\s*$",         "match_all": true }
+      { "key": "selector",              "operator": "equal",          "operand": "string.quoted.double.block",         "match_all": false },
+      { "key": "setting.auto_indent",   "operator": "equal",          "operand": true,                                 "match_all": true },
+      { "key": "selection_empty",       "operator": "equal",          "operand": true,                                 "match_all": true },
+      { "key": "auto_complete_visible", "operator": "equal",          "operand": false,                                "match_all": true },
+      { "key": "preceding_text",        "operator": "regex_contains", "operand": "^\\s*(\"\"\"|''')\\s*$",             "match_all": true }
     ]
   },
   {
@@ -32,11 +32,11 @@
     ],
     "command": "docblockr_python",
     "context": [
-      { "key": "selector",              "operator": "equal",          "operand": "string.quoted.double.block", "match_all": false },
-      { "key": "setting.auto_indent",   "operator": "equal",          "operand": true,                         "match_all": true },
-      { "key": "selection_empty",       "operator": "equal",          "operand": true,                         "match_all": true },
-      { "key": "auto_complete_visible", "operator": "equal",          "operand": false,                        "match_all": true },
-      { "key": "preceding_text",        "operator": "regex_contains", "operand": "^\\s*(\"\"\")\\s*$",         "match_all": true }
+      { "key": "selector",              "operator": "equal",          "operand": "string.quoted.double.block",         "match_all": false },
+      { "key": "setting.auto_indent",   "operator": "equal",          "operand": true,                                 "match_all": true },
+      { "key": "selection_empty",       "operator": "equal",          "operand": true,                                 "match_all": true },
+      { "key": "auto_complete_visible", "operator": "equal",          "operand": false,                                "match_all": true },
+      { "key": "preceding_text",        "operator": "regex_contains", "operand": "^\\s*(\"\"\"|''')\\s*$",             "match_all": true }
     ]
   },
 
@@ -47,11 +47,11 @@
     ],
     "command": "docblockr_python",
     "context": [
-      { "key": "selector",              "operator": "equal",          "operand": "comment.block.python", "match_all": false },
-      { "key": "setting.auto_indent",   "operator": "equal",          "operand": true,                   "match_all": true },
-      { "key": "selection_empty",       "operator": "equal",          "operand": true,                   "match_all": true },
-      { "key": "auto_complete_visible", "operator": "equal",          "operand": false,                  "match_all": true },
-      { "key": "preceding_text",        "operator": "regex_contains", "operand": "^\\s*(\"\"\")\\s*$",   "match_all": true }
+      { "key": "selector",              "operator": "equal",          "operand": "comment.block.python",               "match_all": false },
+      { "key": "setting.auto_indent",   "operator": "equal",          "operand": true,                                 "match_all": true },
+      { "key": "selection_empty",       "operator": "equal",          "operand": true,                                 "match_all": true },
+      { "key": "auto_complete_visible", "operator": "equal",          "operand": false,                                "match_all": true },
+      { "key": "preceding_text",        "operator": "regex_contains", "operand": "^\\s*(\"\"\"|''')\\s*$",             "match_all": true }
     ]
   },
   {
@@ -60,11 +60,11 @@
     ],
     "command": "docblockr_python",
     "context": [
-      { "key": "selector",              "operator": "equal",          "operand": "comment.block.python", "match_all": false },
-      { "key": "setting.auto_indent",   "operator": "equal",          "operand": true,                   "match_all": true },
-      { "key": "selection_empty",       "operator": "equal",          "operand": true,                   "match_all": true },
-      { "key": "auto_complete_visible", "operator": "equal",          "operand": false,                  "match_all": true },
-      { "key": "preceding_text",        "operator": "regex_contains", "operand": "^\\s*(\"\"\")\\s*$",   "match_all": true }
+      { "key": "selector",              "operator": "equal",          "operand": "comment.block.python",               "match_all": false },
+      { "key": "setting.auto_indent",   "operator": "equal",          "operand": true,                                 "match_all": true },
+      { "key": "selection_empty",       "operator": "equal",          "operand": true,                                 "match_all": true },
+      { "key": "auto_complete_visible", "operator": "equal",          "operand": false,                                "match_all": true },
+      { "key": "preceding_text",        "operator": "regex_contains", "operand": "^\\s*(\"\"\"|''')\\s*$",             "match_all": true }
     ]
   },
   {
@@ -73,11 +73,11 @@
     ],
     "command": "docblockr_python",
     "context": [
-      { "key": "selector",              "operator": "equal",          "operand": "comment.block.python", "match_all": false },
-      { "key": "setting.auto_indent",   "operator": "equal",          "operand": true,                   "match_all": true },
-      { "key": "selection_empty",       "operator": "equal",          "operand": true,                   "match_all": true },
-      { "key": "auto_complete_visible", "operator": "equal",          "operand": false,                  "match_all": true },
-      { "key": "preceding_text",        "operator": "regex_contains", "operand": "^\\s*(\"\"\")\\s*$",   "match_all": true }
+      { "key": "selector",              "operator": "equal",          "operand": "comment.block.python",               "match_all": false },
+      { "key": "setting.auto_indent",   "operator": "equal",          "operand": true,                                 "match_all": true },
+      { "key": "selection_empty",       "operator": "equal",          "operand": true,                                 "match_all": true },
+      { "key": "auto_complete_visible", "operator": "equal",          "operand": false,                                "match_all": true },
+      { "key": "preceding_text",        "operator": "regex_contains", "operand": "^\\s*(\"\"\"|''')\\s*$",             "match_all": true }
     ]
   },
 
@@ -92,7 +92,7 @@
       { "key": "setting.auto_indent",   "operator": "equal",          "operand": true,                                 "match_all": true },
       { "key": "selection_empty",       "operator": "equal",          "operand": true,                                 "match_all": true },
       { "key": "auto_complete_visible", "operator": "equal",          "operand": false,                                "match_all": true },
-      { "key": "preceding_text",        "operator": "regex_contains", "operand": "^\\s*(\"\"\")\\s*$",                 "match_all": true }
+      { "key": "preceding_text",        "operator": "regex_contains", "operand": "^\\s*(\"\"\"|''')\\s*$",             "match_all": true }
     ]
   },
   {
@@ -105,7 +105,7 @@
       { "key": "setting.auto_indent",   "operator": "equal",          "operand": true,                                 "match_all": true },
       { "key": "selection_empty",       "operator": "equal",          "operand": true,                                 "match_all": true },
       { "key": "auto_complete_visible", "operator": "equal",          "operand": false,                                "match_all": true },
-      { "key": "preceding_text",        "operator": "regex_contains", "operand": "^\\s*(\"\"\")\\s*$",                 "match_all": true }
+      { "key": "preceding_text",        "operator": "regex_contains", "operand": "^\\s*(\"\"\"|''')\\s*$",             "match_all": true }
     ]
   },
   {
@@ -118,7 +118,7 @@
       { "key": "setting.auto_indent",   "operator": "equal",          "operand": true,                                 "match_all": true },
       { "key": "selection_empty",       "operator": "equal",          "operand": true,                                 "match_all": true },
       { "key": "auto_complete_visible", "operator": "equal",          "operand": false,                                "match_all": true },
-      { "key": "preceding_text",        "operator": "regex_contains", "operand": "^\\s*(\"\"\")\\s*$",                 "match_all": true }
+      { "key": "preceding_text",        "operator": "regex_contains", "operand": "^\\s*(\"\"\"|''')\\s*$",             "match_all": true }
     ]
   }
 ]

--- a/commands.py
+++ b/commands.py
@@ -121,7 +121,7 @@ class DocblockrPythonCommand(sublime_plugin.TextCommand):
         self.trailing_rgn = sublime.Region(position, view.line(position).end())
         self.trailing_string = view.substr(self.trailing_rgn).strip()
         # drop trailing '"""'
-        self.trailing_string = escape(re.sub(r'\s*"""\s*$', '', self.trailing_string))
+        self.trailing_string = escape(re.sub(r'\s*("""|\'\'\')\s*$', '', self.trailing_string))
 
         self.parser = parser = get_parser(view)
 

--- a/parsers/parser.py
+++ b/parsers/parser.py
@@ -676,7 +676,6 @@ class PythonParser:
             if match is not None:
                 s = match.group(0).strip()[0:3]
                 if s in ['"""', "'''"]:
-                    print('setting closing string to {}'.format(s))
                     self.closing_string = s
                 else:
                     raise Exception('could not find closing string.  Match was: {}'.format(match))

--- a/parsers/parser.py
+++ b/parsers/parser.py
@@ -208,16 +208,12 @@ class PythonParser:
 
     Contains the relevant parsing configuration to be able to handle Python style
     source files.
-
-    Variables:
-        closing_string {String}
     """
-
-    closing_string = '"""'
 
     def __init__(self, view_settings=None):
         """---."""
         self.view_settings = view_settings
+        self.closing_string = '"""'
 
     @classmethod
     def get_definition(self, view, position):
@@ -676,13 +672,23 @@ class PythonParser:
         Returns:
             {Bool} True if the docstring is confirmed closed
         """
+        def set_closing_string(match):
+            if match is not None:
+                s = match.group(0).strip()[0:3]
+                if s in ['"""', "'''"]:
+                    print('setting closing string to {}'.format(s))
+                    self.closing_string = s
+                else:
+                    raise Exception('could not find closing string.  Match was: {}'.format(match))
+
         indentation_level = view.indentation_level(position)
 
         # Check the current line first, and ignore if docstring is closed on this line
         line = view.substr(view.line(position))
-        match = re.search(r'^\s*""".*"""\s*$', line)
+        match = re.search(r'^\s*(""".*"""|\'\'\'.*\'\'\')\s*$', line)
 
         if match is not None:
+            set_closing_string(match)
             return False
 
         for current_line in read_next_line(view, position):
@@ -701,7 +707,10 @@ class PythonParser:
                 break
 
             # Line only contains whitespace and """
-            if re.search(r'^\s*"""', current_line_string) is not None:
+            match = re.search(r'^\s*("""|\'\'\')', current_line_string)
+            if match is not None:
+                set_closing_string(match)
                 return True
 
+        set_closing_string(re.search(r'^\s*("""|\'\'\')', line))
         return False


### PR DESCRIPTION
The reasoning behind this request is that I've gotten into the habit of defining my docstrings using single quotes, e.g.:

    def foo():
        '''docstring'''

I've update the key mapping, the parser, and the DocblockrPythonCommand class.  When the parser checks if the docstring has been closed, it assigns the closing string to what it found in the regex.  This means that it's completely automatic and handles both without and configuration settings or setup.